### PR TITLE
Don't generate an unhandled Deferred.

### DIFF
--- a/txrdq/rdq.py
+++ b/txrdq/rdq.py
@@ -261,8 +261,9 @@ class ResizableDispatchQueue(object):
         @param job: a L{Job} to get underway.  If the job is a no-op, do
         nothing.
 
-        @return: Unless the job is a no-op, return a C{Deferred} that will fire
-        with the result of processing the job. Otherwise, return C{None}.
+        @return: C{None}, if the job is a no-op, or if the job has already
+                 finished or failed.  Otherwise, a C{Deferred} that will
+                 fire with the result of processing the job.
         """
         if job is not self._NOOP:
             self._underway.add(job)
@@ -274,8 +275,9 @@ class ResizableDispatchQueue(object):
                 return job.waiting[0]
             except IndexError:
                 # There are no Deferreds waiting on the result of
-                # this job.
-                return None
+                # this job, indicating that the job has already
+                # finished or failed.
+                pass
 
     def getWidth(self):
         """

--- a/txrdq/rdq.py
+++ b/txrdq/rdq.py
@@ -268,12 +268,14 @@ class ResizableDispatchQueue(object):
             self._underway.add(job)
             job.launch(self._func)
             # Return the first waiting Deferred for the job, if any.
-            # Otherwise return a new Deferred for the job. Our self._coop
-            # (a task.Cooperator) will wait for the Deferred result.
+            # Our self._coop (a task.Cooperator) will wait for the
+            # Deferred result.
             try:
                 return job.waiting[0]
             except IndexError:
-                return job.watch()
+                # There are no Deferreds waiting on the result of
+                # this job.
+                return None
 
     def getWidth(self):
         """


### PR DESCRIPTION
This seemingly tiny change fixes the problem demonstrated at http://stackoverflow.com/questions/9728781/testing-a-failing-job-in-resizabledispatchqueue-with-trial, with all tests still passing.
