### PR TITLE
Don't allow a failure to go unhandled in a deferred

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,3 @@
+Terry Jones (@terrycojones)
+L. Daniel Burr (@ldanielburr)
+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,17 @@
+Version 0.2.14 notes (January 25, 2014)
+---------------------------------------
+
+There was a problem when running trial tests with a job handler that raised an
+error. This was due to calling job.watch and not ignoring the error it received.
+The original problem was reported at http://stackoverflow.com/questions/9728781/testing-a-failing-job-in-resizabledispatchqueue-with-trial
+(See also the comment below for version 0.2.13, which almost certainly introduced
+this bug due to an incorrect fix.)
+
+Thanks to L. Daniel Burr (@ldanielburr) who also ran across this, found the
+problem, and fixed it.
+
 Version 0.2.13 notes (July 13, 2011)
-----------------------------------
+------------------------------------
 
 Make sure ResizableDispatchQueue._launchJob always returns a Deferred.  I'm
 not sure how, but sometimes when there is no waiting Deferred on the job,
@@ -11,18 +23,18 @@ somehow triggering this (see testPuttingMoreThanWidthOnlyDispatchesWidth in
 test/test_rdq.py) and were not being waited for by the cooperator.
 
 Version 0.2.12 notes (July 12, 2011)
-----------------------------------
+------------------------------------
 
 Don't use next() in txrdq/dpq.py as it's new in Python 2.6 and I'd like to
 be compatible with earlier versions.
 
 Version 0.2.11 notes (July 11, 2011)
-----------------------------------
+------------------------------------
 
 Updated .bzrignore.
 
 Version 0.2.10 notes (July 11, 2011)
-----------------------------------
+------------------------------------
 
 Fixed a bug wherein an initially non-zero queue would have Deferreds
 waiting for a job arg and would start job processing on the next put even

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test upload wc pep8 pyflakes clean
+.PHONY: test upload wc pep8 pyflakes clean lint
 XARGS := xargs -0 $(shell test $$(uname) = Linux && echo -r)
 
 test:
@@ -16,7 +16,9 @@ pep8:
 pyflakes:
 	find . -name '*.py' -print0 | $(XARGS) pyflakes
 
+lint: pep8 pyflakes
+
 clean:
-	find . \( -name '*.pyc' -o -name '*~' \) -print0 | $(xargs) rm
+	find . \( -name '*.pyc' -o -name '*~' \) -print0 | $(XARGS) rm
 	find . -type d -name _trial_temp -print0 | $(XARGS) rm -r
 	rm -fr MANIFEST dist

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 d = dict(name='txRDQ',
-         version='0.2.13',
+         version='0.2.14',
          provides=['txrdq'],
          maintainer='Fluidinfo Inc.',
          maintainer_email='info@fluidinfo.com',

--- a/txrdq/test/test_rdq.py
+++ b/txrdq/test/test_rdq.py
@@ -661,7 +661,6 @@ class TestDeferredErrorHandling(unittest.TestCase):
     http://stackoverflow.com/questions/9728781/\
     testing-a-failing-job-in-resizabledispatchqueue-with-trial
     """
-
     def testRaiseFailsWithJob(self):
         """
         Raising an exception in the job handler should result in a failure

--- a/txrdq/test/test_rdq.py
+++ b/txrdq/test/test_rdq.py
@@ -661,12 +661,12 @@ class TestDeferredErrorHandling(unittest.TestCase):
     http://stackoverflow.com/questions/9728781/\
     testing-a-failing-job-in-resizabledispatchqueue-with-trial
     """
+
     def testRaiseFailsWithJob(self):
         """
         Raising an exception in the job handler should result in a failure
         that contains a L{txrdq.job.Job} value.
         """
-
         def raiseException(jobarg):
             raise Exception()
 


### PR DESCRIPTION
Add an addErrback to ignore any error in the deferred we get from watching a launched a job. Hide the 'waiting' list on a job as we no longer need to access it. Cleaned up job docstring a little.

All the debugging & thinking to find this problem was done by @ldanielburr

Fixes #4
